### PR TITLE
Fix templates not being passed to new pages

### DIFF
--- a/packages/migration_tool/controller.php
+++ b/packages/migration_tool/controller.php
@@ -47,7 +47,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'migration_tool';
     protected $appVersionRequired = '8.3.1';
-    protected $pkgVersion = '0.9.1';
+    protected $pkgVersion = '0.9.2';
     protected $pkgAutoloaderMapCoreExtensions = true;
     protected $pkgAutoloaderRegistries = array(
         'src/PortlandLabs/Concrete5/MigrationTool' => '\PortlandLabs\Concrete5\MigrationTool',

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Routine/CreatePageStructureRoutineAction.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Routine/CreatePageStructureRoutineAction.php
@@ -56,7 +56,7 @@ class CreatePageStructureRoutineAction extends AbstractPageAction
         $data['cDescription'] = $page->getDescription();
         $data['cHandle'] = substr($page->getBatchPath(), strrpos($page->getBatchPath(), '/') + 1);
 
-        $newPage = $parent->add($type, $data);
+        $newPage = $parent->add($type, $data, is_object($template) ? $template : false);
         $logger->logPublishComplete($page, $newPage);
     }
 }


### PR DESCRIPTION
When importing a page, if you map a template to something other than the default template for that page type it will be ignored, as page::add function needs a template object or it will use the default template for that page type.

This PR fixes that issue so when importing it will use the correct page template