### PR TITLE
Include parent page itself when filtering by parent page

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
@@ -55,6 +55,11 @@ class Page extends SinglePage
         $pl->setItemsPerPage(1000);
         $results = $pl->getResults();
         $items = array();
+        if (isset($parent) && !$parent->isError()) {
+            $item = new \PortlandLabs\Concrete5\MigrationTool\Entity\Export\Page();
+            $item->setItemId($parent->getCollectionID());
+            $items[] = $item;
+        }
         foreach ($results as $c) {
             $item = new \PortlandLabs\Concrete5\MigrationTool\Entity\Export\Page();
             $item->setItemId($c->getCollectionID());


### PR DESCRIPTION
Let's assume we have a very simple site with two locales, `en_US` published under `/` and `it_IT` published under `/it` :

![immagine](https://github.com/user-attachments/assets/7ee9ffcd-ee0e-431d-b9cc-3830ea278e97)

![immagine](https://github.com/user-attachments/assets/f89fe5ef-6ca7-422a-a00b-deebe839bd0b)

There's no way to choose the `/it` page:

1. If no parent page is selected, we have a list of all the pages under the  `en_US` tree:
   ![immagine](https://github.com/user-attachments/assets/9b6e20a8-ea63-4518-9e7d-dc53f8846e7a)
2. If I choose the `/` parent page:
   ![immagine](https://github.com/user-attachments/assets/4d70f678-b75d-44b6-9add-2dc2ed9c0bba)
2. If I choose the `/it` parent page:
   ![immagine](https://github.com/user-attachments/assets/f486b4f2-6e0b-416e-8b27-aa3656682932)

I think the cleanest solution is to include the parent page itself when filtering:

![immagine](https://github.com/user-attachments/assets/19588e97-5052-4a8d-adeb-2037e88700cf)
