### PR TITLE
Display path of root page

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
@@ -33,7 +33,7 @@ class SinglePage extends AbstractType
         $c = \Page::getByID($exportItem->getItemIdentifier());
 
         return array(
-            $c->getCollectionPath(),
+            $c->getCollectionPath() ?: '/',
             $c->getCollectionName(),
         );
     }


### PR DESCRIPTION
When we add pages to the export batch, we see the paths of the pages that can be added, except the one of the homepage:

![immagine](https://github.com/user-attachments/assets/11447746-8bf1-4b06-9279-2a7f097dc1b0)

What about displaying a `/` for it?