### PR TITLE
Fix handling of "Include system pages"

### DIFF
--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
@@ -25,7 +25,6 @@ class Page extends SinglePage
         $pl = new PageList();
         $site = \Core::make('site')->getActiveSiteForEditing();
         $pl->setSiteTreeObject($site->getSiteTreeObject());
-        $pl->includeSystemPages();
         $query = $request->query->all();
 
         $keywords = $query['keywords'];


### PR DESCRIPTION
When retrieving the list of pages, we always have "system pages" in the list:

![immagine](https://github.com/user-attachments/assets/4ff3ca31-308c-455b-87d1-1bda00739c5d)


We currently have:

```php
$pl->includeSystemPages();
// ...
$includeSystemPages = $query['includeSystemPages'];
// ...
if($includeSystemPages) {
    $pl->includeSystemPages();
}
```

The first `$pl->includeSystemPages();` is wrong, isn't it?
