### PR TITLE
Export page aliases and external links

### DIFF
--- a/packages/migration_tool/controllers/single_page/dashboard/system/migration/export.php
+++ b/packages/migration_tool/controllers/single_page/dashboard/system/migration/export.php
@@ -4,7 +4,6 @@ namespace Concrete\Package\MigrationTool\Controller\SinglePage\Dashboard\System\
 use Concrete\Core\Application\EditResponse;
 use Concrete\Core\File\File;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
-use Concrete\Package\MigrationTool\Page\Controller\DashboardPageController;
 use Doctrine\Common\Collections\ArrayCollection;
 use PortlandLabs\Concrete5\MigrationTool\Entity\Export\Batch;
 use PortlandLabs\Concrete5\MigrationTool\Entity\Export\ObjectCollection;

--- a/packages/migration_tool/elements/export/search/page.php
+++ b/packages/migration_tool/elements/export/search/page.php
@@ -39,4 +39,7 @@ foreach ($list as $type) {
     <div class="checkbox">
         <label> <?= $form->checkbox('includeExternalLinks', 1, !empty($includeExternalLinks)) ?><?=t('Include External Links'); ?></label>
     </div>
+    <div class="checkbox">
+        <label> <?= $form->checkbox('includeAliases', 1, !empty($includeAliases)) ?><?=t('Include Page Aliases'); ?></label>
+    </div>
 </div>

--- a/packages/migration_tool/elements/export/search/page.php
+++ b/packages/migration_tool/elements/export/search/page.php
@@ -34,6 +34,9 @@ foreach ($list as $type) {
 
 <div class="form-group">
 	<div class="checkbox">
-    	<label> <?php echo $form->checkbox('includeSystemPages', 1, $includeSystemPages);  ?><?=t('Include System Pages'); ?></label>
+    	<label> <?php echo $form->checkbox('includeSystemPages', 1, !empty($includeSystemPages));  ?><?=t('Include System Pages'); ?></label>
 	</div>
+    <div class="checkbox">
+        <label> <?= $form->checkbox('includeExternalLinks', 1, !empty($includeExternalLinks)) ?><?=t('Include External Links'); ?></label>
+    </div>
 </div>

--- a/packages/migration_tool/elements/export/search/page.php
+++ b/packages/migration_tool/elements/export/search/page.php
@@ -10,6 +10,11 @@ $pagetypes = array('' => t('** Choose a page type'));
 foreach ($list as $type) {
     $pagetypes[$type->getPageTypeID()] = $type->getPageTypeDisplayName();
 }
+if (version_compare(APP_VERSION, '8.5.19') <= 0) {
+    $whyNoAdditionalTypes = t("Your version of concrete5 doesn't support exporting external links and aliases: please upgrade to a newer version.");
+} else {
+    $whyNoAdditionalTypes = '';
+}
 ?>
 <div class="form-group">
     <label class="control-label"><?=t('Keywords')?></label>
@@ -34,12 +39,35 @@ foreach ($list as $type) {
 
 <div class="form-group">
 	<div class="checkbox">
-    	<label> <?php echo $form->checkbox('includeSystemPages', 1, !empty($includeSystemPages));  ?><?=t('Include System Pages'); ?></label>
+    	<label>
+            <?= $form->checkbox('includeSystemPages', 1, !empty($includeSystemPages)) ?>
+            <?= t('Include System Pages') ?>
+        </label>
 	</div>
     <div class="checkbox">
-        <label> <?= $form->checkbox('includeExternalLinks', 1, !empty($includeExternalLinks)) ?><?=t('Include External Links'); ?></label>
+        <label>
+            <?= $form->checkbox('includeExternalLinks', 1, !empty($includeExternalLinks), $whyNoAdditionalTypes === '' ? [] : ['disabled' => 'disabled']) ?>
+            <?= t('Include External Links') ?>
+            <?php
+            if ($whyNoAdditionalTypes !== '') {
+                ?>
+                <i class="fa fa-ban text-warning launch-tooltip" title="<?= h($whyNoAdditionalTypes) ?>"></i>
+                <?php
+            }
+            ?>
+        </label>
     </div>
     <div class="checkbox">
-        <label> <?= $form->checkbox('includeAliases', 1, !empty($includeAliases)) ?><?=t('Include Page Aliases'); ?></label>
+        <label>
+            <?= $form->checkbox('includeAliases', 1, !empty($includeAliases), $whyNoAdditionalTypes === '' ? [] : ['disabled' => 'disabled']) ?>
+            <?=t('Include Page Aliases') ?>
+            <?php
+            if ($whyNoAdditionalTypes !== '') {
+                ?>
+                <i class="fa fa-ban text-warning launch-tooltip" title="<?= h($whyNoAdditionalTypes) ?>"></i>
+                <?php
+            }
+            ?>
+        </label>
     </div>
 </div>

--- a/packages/migration_tool/elements/export/search/page.php
+++ b/packages/migration_tool/elements/export/search/page.php
@@ -10,10 +10,11 @@ $pagetypes = array('' => t('** Choose a page type'));
 foreach ($list as $type) {
     $pagetypes[$type->getPageTypeID()] = $type->getPageTypeDisplayName();
 }
-if (version_compare(APP_VERSION, '8.5.19') <= 0) {
-    $whyNoAdditionalTypes = t("Your version of concrete5 doesn't support exporting external links and aliases: please upgrade to a newer version.");
-} else {
+// Let's check if we have a class that has been introduced in the core when we added support for exporting page aliases and external links
+if (class_exists('Concrete\Core\Backup\ContentImporter\Exception\MissingPageAtPathException')) {
     $whyNoAdditionalTypes = '';
+} else {
+    $whyNoAdditionalTypes = t("Your version of concrete5 doesn't support exporting external links and aliases: please upgrade to a newer version.");
 }
 ?>
 <div class="form-group">

--- a/packages/migration_tool/single_pages/dashboard/system/migration/finalize_export_batch.php
+++ b/packages/migration_tool/single_pages/dashboard/system/migration/finalize_export_batch.php
@@ -1,12 +1,25 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Form\Service\Form $form	
+ *
+ * @var PortlandLabs\Concrete5\MigrationTool\Entity\Export\Batch $batch
+ * @var Concrete\Core\Entity\File\File[] $files
+ * @var string $xml
+ */
+
+?>
 <div class="ccm-dashboard-header-buttons">
-    <a href="<?=$view->action('view_batch', $batch->getID())?>" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?=t('Back to Batch')?></a>
+    <a href="<?= h($view->action('view_batch', $batch->getID())) ?>" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?= t('Back to Batch') ?></a>
 </div>
 
-<?php if (count($files)) {
+<?php
+if ($files !== []) {
     ?>
-
-    <script type="text/javascript">
+    <script>
         $(function() {
             $('input[data-checkbox=select-all]').on('click', function() {
                 if ($(this).is(':checked')) {
@@ -27,48 +40,78 @@
 
         });
     </script>
-
-    <form method="post" action="<?=$view->action('download_files')?>">
-        <input type="hidden" name="id" value="<?=$batch->getID()?>">
-        <?=Loader::helper('validation/token')->output('download_files')?>
-        <button style="float: right" disabled class="btn btn-xs btn-default" data-action="download-files" type="submit"><?=t('Download Files')?></button>
-        <h3><?=t('Files')?></h3>
-
+    <form method="POST" action="<?= h($view->action('download_files')) ?>">
+        <?php $token->output('download_files') ?>
+        <input type="hidden" name="id" value="<?= $batch->getID() ?>" />
+        <button style="float: right" disabled class="btn btn-xs btn-default" data-action="download-files" type="submit"><?= t('Download Files') ?></button>
+        <h3><?= t('Files') ?></h3>
         <table class="table table-striped zebra-striped">
             <thead>
-            <tr>
-                <th><input type="checkbox" data-checkbox="select-all"></th>
-                <th><?=t('ID')?></th>
-                <th style="width: 100%"><?=t('Filename')?></th>
-            </tr>
+                <tr>
+                    <th><input type="checkbox" data-checkbox="select-all"></th>
+                    <th><?= t('ID') ?></th>
+                    <th style="width: 100%"><?= t('Filename') ?></th>
+                </tr>
             </thead>
             <tbody>
-            <?php foreach ($files as $file) {
-    ?>
-                <tr>
-                    <td><input type="checkbox" data-checkbox="batch-file" name="batchFileID[]" value="<?=$file->getFileID()?>"></td>
-                    <td><?=$file->getFileID()?></td>
-                    <td><?=$file->getFileName()?></td>
-                </tr>
-            <?php 
-}
-    ?>
+                <?php
+                foreach ($files as $file) {
+                    ?>
+                    <tr>
+                        <td><input type="checkbox" data-checkbox="batch-file" name="batchFileID[]" value="<?= $file->getFileID() ?>"></td>
+                        <td><?= $file->getFileID() ?></td>
+                        <td><?= h($file->getFileName()) ?></td>
+                    </tr>
+                    <?php
+                }
+                ?>
             </tbody>
         </table>
     </form>
-<?php 
+    <?php
 } else {
     ?>
-    <h3><?=t('Files')?></h3>
-    <p><?=t('No referenced files found.')?></p>
-<?php 
-} ?>
+    <h3><?= t('Files') ?></h3>
+    <p><?= t('No referenced files found.') ?></p>
+    <?php
+}
+?>
+<h3><?= t('Content XML') ?></h3>
+<div class="btn-group">
+    <button type="button" id="mt-export-xml-view" class="btn btn-default"><?= t('View XML') ?></button>
+    <button type="button" id="mt-export-xml-download" class="btn btn-default"><?= t('Download XML') ?></button>
+</div>
+<script>
+addEventListener('DOMContentLoaded', () => {
 
-<h3><?=t('Content XML')?></h3>
-<form method="post" action="<?=$view->action('export_batch_xml', $batch->getID())?>">
-    <div class="btn-group">
-        <button type="submit" name="view" value="1" class="btn btn-default"><?=t('View XML')?></button>
-        <button type="submit" name="download" value="1" class="btn btn-default"><?=t('Download XML')?></button>
-    </div>
-</form>
+const XML = <?= json_encode($xml) ?>;
+function sendXML(download)
+{
+    const blob = new Blob([XML], {type: 'application/xml; charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    if (download) {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'export.xml';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    } else {
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 15000);
+    }
+}    
 
+document.querySelector('#mt-export-xml-view').addEventListener('click', (e) => {
+    e.preventDefault();
+    sendXML(false);
+});
+
+document.querySelector('#mt-export-xml-download').addEventListener('click', (e) => {
+    e.preventDefault();
+    sendXML(true);
+});
+
+});
+</script>

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Exporter.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Exporter.php
@@ -8,8 +8,14 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Exporter
 {
+    /**
+     * @var \PortlandLabs\Concrete5\MigrationTool\Entity\Export\Batch
+     */
     protected $batch;
-    protected $built = false;
+
+    /**
+     * @var \SimpleXMLElement|null
+     */
     protected $element;
 
     public function __construct(Batch $batch)
@@ -27,9 +33,12 @@ class Exporter
         }
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     public function getElement()
     {
-        if (!$this->built) {
+        if (!$this->element) {
             $this->build();
         }
 
@@ -38,6 +47,8 @@ class Exporter
 
     /**
      * Loops through all pages and returns files referenced.
+     *
+     * @return \Concrete\Core\Entity\File\File[]
      */
     public function getReferencedFiles()
     {

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
@@ -31,6 +31,7 @@ class Page extends SinglePage
         $startingPoint = (int) $query->get('startingPoint');
         $datetime = \Core::make('helper/form/date_time')->translate('datetime', $query->all());
         $includeSystemPages = $query->get('includeSystemPages');
+        $includeAliases = $query->get('includeAliases');
 
         $pl->ignorePermissions();
         if ($startingPoint) {
@@ -51,8 +52,11 @@ class Page extends SinglePage
         if ($keywords) {
             $pl->filterByKeywords($keywords);
         }
-        if($includeSystemPages) {
+        if ($includeSystemPages) {
             $pl->includeSystemPages();
+        }
+        if ($includeAliases) {
+            $pl->includeAliases();
         }
         $pl->setItemsPerPage(1000);
         $results = $pl->getResults();
@@ -64,7 +68,8 @@ class Page extends SinglePage
         }
         foreach ($results as $c) {
             $item = new \PortlandLabs\Concrete5\MigrationTool\Entity\Export\Page();
-            $item->setItemId($c->getCollectionID());
+            $cID = $includeAliases ? $c->getCollectionPointerOriginalID() : 0;
+            $item->setItemId($cID ?: $c->getCollectionID());
             $items[] = $item;
         }
         if ($query->get('includeExternalLinks')) {

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Page.php
@@ -23,13 +23,13 @@ class Page extends SinglePage
     public function getResults(Request $request)
     {
         $pl = new PageList();
-        $query = $request->query->all();
+        $query = $request->query;
 
-        $keywords = $query['keywords'];
-        $ptID = $query['ptID'];
-        $startingPoint = intval($query['startingPoint']);
-        $datetime = \Core::make('helper/form/date_time')->translate('datetime', $query);
-        $includeSystemPages = $query['includeSystemPages'];
+        $keywords = $query->get('keywords');
+        $ptID = $query->get('ptID');
+        $startingPoint = (int) $query->get('startingPoint');
+        $datetime = \Core::make('helper/form/date_time')->translate('datetime', $query->all());
+        $includeSystemPages = $query->get('includeSystemPages');
 
         $pl->ignorePermissions();
         if ($startingPoint) {
@@ -52,7 +52,7 @@ class Page extends SinglePage
         if($includeSystemPages) {
             $pl->includeSystemPages();
         }    
-
+        $pl->includeAliases();
         $pl->setItemsPerPage(1000);
         $results = $pl->getResults();
         $items = array();

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
@@ -32,13 +32,18 @@ class SinglePage extends AbstractType
     {
         $c = \Page::getByID($exportItem->getItemIdentifier());
         if ($c->isExternalLink()) {
-            $path = $c->generatePagePath();
+            $path = h($c->generatePagePath());
+            $path .= ' <i class="fa fa-external-link"></i> ' . h($c->getCollectionPointerExternalLink());
         } else {
-            $path = $c->getCollectionPath() ?: '/';
+            $path = h($c->getCollectionPath() ?: '/');
+            if ($c->isAliasPage()) {
+                $originalPage = \Page::getByID($c->getCollectionID());
+                $path .= ' <i class="fa fa-sign-in"></i> ' . h($originalPage->getCollectionPath());
+            }
         }
         return array(
             $path,
-            $c->getCollectionName(),
+            h($c->getCollectionName()),
         );
     }
 

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
@@ -49,7 +49,7 @@ class SinglePage extends AbstractType
             $c = \Page::getByID($id);
             if (is_object($c) && !$c->isError()) {
                 $page = new \PortlandLabs\Concrete5\MigrationTool\Entity\Export\SinglePage();
-                $page->setItemId($c->getCollectionID());
+                $page->setItemId($c->getCollectionPointerOriginalID() ?: $c->getCollectionID());
                 $items[] = $page;
             }
         }

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/SinglePage.php
@@ -31,9 +31,13 @@ class SinglePage extends AbstractType
     public function getResultColumns(ExportItem $exportItem)
     {
         $c = \Page::getByID($exportItem->getItemIdentifier());
-
+        if ($c->isExternalLink()) {
+            $path = $c->generatePagePath();
+        } else {
+            $path = $c->getCollectionPath() ?: '/';
+        }
         return array(
-            $c->getCollectionPath() ?: '/',
+            $path,
             $c->getCollectionName(),
         );
     }

--- a/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Stack.php
+++ b/packages/migration_tool/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/Stack.php
@@ -51,7 +51,11 @@ class Stack extends AbstractType
                 break;
             default:
                 $c = \Concrete\Core\Page\Stack\Stack::getByID($exportItem->getItemIdentifier());
-                $type = t('Stack');
+                if ($c && !$c->isError() && $c->getStackType() == $c::ST_TYPE_GLOBAL_AREA) {
+                    $type = t('Global Area');
+                } else {
+                    $type = t('Stack');
+                }
                 break;
         }
 


### PR DESCRIPTION
With https://github.com/concretecms/concretecms/pull/12300, concrete5 8.x can export/import page aliases and external links.

What about adding the possibility to export them?
